### PR TITLE
Sling bug fixes

### DIFF
--- a/SlungPlanet.gd
+++ b/SlungPlanet.gd
@@ -2,14 +2,16 @@ extends RigidBody2D
 
 enum {UNPRESSED, PRESSED, SHOT, PROJECTING}
 
-var state = UNPRESSED  # whether the planet has been preseed - default undefined
+@export var age = 0
 
-@onready var centre_position = $"../Sling/Centre".global_position
+@export var state = UNPRESSED  # whether the planet has been preseed - default undefined
+
+@onready var centre = $"../Sling/Centre"
 @onready var sling = $"../Sling"
 @onready var arrow = $"Arrow/Sprite"
 @onready var root = $".."
-@onready var launchpad_position = $"../..".global_position
-@onready var boundary = Rect2(launchpad_position.x - 100, launchpad_position.y - 100, 200.0, 200.0)
+@onready var launchpad_position = $"../../Area2D/CollisionShape2D".global_position
+@onready var boundary = Rect2(launchpad_position.x - 167.5, launchpad_position.y - 167.5, 335.0, 335.0)
 
 var force = 10;
 var projected_velocity = Vector2.ZERO
@@ -25,7 +27,7 @@ func _ready():
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(_delta):
-	if state != PRESSED && !boundary.has_point(global_position):
+	if state != PRESSED && !boundary.grow(40).has_point(global_position):
 		# Retain the velocity and the global position before
 		# resetting the slung planet
 		projected_velocity = linear_velocity
@@ -33,7 +35,6 @@ func _process(_delta):
 
 		# Disable and freeze so we don't move or interact
 		set_deferred("disable_mode", true)
-		set_deferred("freeze", true)
 
 		# Set the global position back to our initial postiion
 		set_global_position(root.global_position)
@@ -63,9 +64,8 @@ func _process(_delta):
 		var stage = $"../../.."
 		stage.add_child(planet)
 
-		# We can now interact
 		set_deferred("disable_mode", false)
-		set_deferred("freeze", false)
+		set_deferred("freeze", true)
 		state = UNPRESSED
 
 
@@ -81,13 +81,12 @@ func _input(event):
 		on_drag()
 
 		if event is InputEventMouseButton && !event.is_pressed():
-			state = UNPRESSED
 			shoot()
 
 
 func on_drag():
 	arrow.visible = true
-	var distance = centre_position - global_position
+	var distance = centre.global_position - global_position
 	var scale = distance.length() / 100
 	arrow.scale.x = scale
 	arrow.scale.y = scale
@@ -99,7 +98,7 @@ func on_drag():
 func shoot():
 	arrow.visible = false
 	sling.reset_line_to_origin()
-	var distance = centre_position - global_position
+	var distance = centre.global_position - global_position
 	var impulse = distance.normalized() * distance.length() * force
 
 	apply_impulse(distance, impulse)
@@ -108,6 +107,7 @@ func shoot():
 
 func _on_input_event(_viewport, event, _shape_idx):
 	if event is InputEventMouseButton && event.is_pressed():
+		set_deferred("freeze", false)
 		state = PRESSED
 
 

--- a/launch_pad.gd
+++ b/launch_pad.gd
@@ -1,0 +1,18 @@
+extends Node2D
+
+enum {OUT, IN}
+
+var state = OUT
+
+
+func _on_area_2d_input_event(viewport, event, shape_idx):
+	if state == IN and event is InputEventMouse and $"SlingNode/SlungPlanet".state == 0:
+		$"SlingNode".set_global_position(event.position)
+
+
+func _on_area_2d_mouse_entered():
+	state = IN
+
+
+func _on_area_2d_mouse_exited():
+	state = OUT

--- a/launch_pad.tscn
+++ b/launch_pad.tscn
@@ -1,12 +1,14 @@
-[gd_scene load_steps=4 format=3 uid="uid://b1tq0qy7byxj5"]
+[gd_scene load_steps=5 format=3 uid="uid://b1tq0qy7byxj5"]
 
+[ext_resource type="Script" path="res://launch_pad.gd" id="1_l10nf"]
 [ext_resource type="Texture2D" uid="uid://cl0v5nhohdgiw" path="res://sprites/launcharea.svg" id="2_fusrb"]
 [ext_resource type="PackedScene" uid="uid://dsrts0kqy3ia4" path="res://sling.tscn" id="3_re4ss"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_2tkvs"]
-size = Vector2(200, 200)
+size = Vector2(335, 335)
 
 [node name="LaunchPad" type="Node2D"]
+script = ExtResource("1_l10nf")
 
 [node name="Area2D" type="Area2D" parent="."]
 monitoring = false
@@ -16,7 +18,11 @@ monitorable = false
 texture = ExtResource("2_fusrb")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
+position = Vector2(-1.5, 26.5)
 shape = SubResource("RectangleShape2D_2tkvs")
 
 [node name="SlingNode" parent="." instance=ExtResource("3_re4ss")]
-position = Vector2(-50, -50)
+
+[connection signal="input_event" from="Area2D" to="." method="_on_area_2d_input_event"]
+[connection signal="mouse_entered" from="Area2D" to="." method="_on_area_2d_mouse_entered"]
+[connection signal="mouse_exited" from="Area2D" to="." method="_on_area_2d_mouse_exited"]

--- a/sling.tscn
+++ b/sling.tscn
@@ -76,6 +76,7 @@ input_pickable = true
 mass = 0.22
 gravity_scale = 2.66454e-15
 lock_rotation = true
+freeze = true
 script = ExtResource("2_4lus2")
 
 [node name="Sprite" type="Sprite2D" parent="SlungPlanet"]


### PR DESCRIPTION
- Use accurate boundary based on the dotted lines of the launch area
- Add a 40px hysteresis before projecting SlungPlanet as a new planet to avoid infinite collisions around the boundary
- Make the sling to follow around the mouse when the mouse is hovering over the launch area. Allow the planet to be launched from anywhere within the launch area.
- Set SlungPlanet's age so it doesn't crash the game when colliding with a planet.